### PR TITLE
fix(lint): fix 2 ESLint errors blocking CI

### DIFF
--- a/client/src/components/pages/BacklogPage.tsx
+++ b/client/src/components/pages/BacklogPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { useTasks } from "@/hooks/useTasks";
 import {
   Card,
@@ -42,25 +42,16 @@ interface BacklogTasks {
 
 export default function BacklogPage() {
   const { tasks: allTasks, loading, error, updateTask } = useTasks();
-  const [tasks, setTasks] = useState<BacklogTasks>({
-    todo: [],
-    "in-progress": [],
-    review: [],
-    done: [],
-    qa: [],
-  });
+  const tasks = useMemo<BacklogTasks>(() => {
+    const organized: BacklogTasks = {
+      todo: [],
+      "in-progress": [],
+      review: [],
+      done: [],
+      qa: [],
+    };
 
-  // Organize tasks by status
-  useEffect(() => {
     if (!loading && allTasks.length > 0) {
-      const organized: BacklogTasks = {
-        todo: [],
-        "in-progress": [],
-        review: [],
-        done: [],
-        qa: [],
-      };
-
       allTasks.forEach((task) => {
         switch (task.status) {
           case "todo":
@@ -80,9 +71,9 @@ export default function BacklogPage() {
             break;
         }
       });
-
-      setTasks(organized);
     }
+
+    return organized;
   }, [allTasks, loading]);
 
   if (loading) {

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -606,10 +606,12 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  const widthRef = React.useRef<string | null>(null);
+  if (widthRef.current === null) {
+    // eslint-disable-next-line react-hooks/purity -- intentional random width for skeleton loading animation
+    widthRef.current = `${Math.floor(Math.random() * 40) + 50}%`;
+  }
+  const width = widthRef.current;
 
   return (
     <div


### PR DESCRIPTION
## Problema
Los 2 errores de ESLint bloqueaban el CI (Lint 22.x) impidiendo merge de cualquier PR.

## Fixes

### BacklogPage.tsx — react-hooks/set-state-in-effect
- Antes: useState + useEffect llamando setTasks() sincronamente → cascading renders
- Después: useMemo para derivar estado organizado directamente (patrón correcto)

### sidebar.tsx — react-hooks/purity
- Antes: Math.random() dentro de useMemo con deps vacíos
- Después: useRef lazy-init + eslint-disable con comentario explicativo

## Resultado: 0 errors, 70 warnings — CI puede continuar

Closes #24

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>